### PR TITLE
Going to use token stored on travis-ci.com instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   - JS=true
-  - secure: I8kx0RezPnXgm5+q3K59YoJFyYkMy0OkynBJOJLGXsRLdAH8+THrjfLfZbhURJ7tXABCQ3DFFJuCfLzZYau2PnH80LKWPT5IG2jy3DxhYDgKGY3BEZxHzj8qjGWPW9ENBS/CwUi9k9D1Tp2CtkpLXV3vA3mz9S8HFZ/z/6qouPlM4H0sq/gq88f6TCEAtgldhtnowWNJjWKsL7RsUkAuZoWUBomfZvfylDltqXQfk5BogV97zEpxyduuoLNjApTi2saRSw5kPiCVpT+92gHMLTJowegDqo8baoGZeqyJ7UayJh1N6VVlnDpJb1Bt7C/NjrMBpVGCsrU5Lj2zFJyYoC/XtCwyaaAcmsvtADOK0ZbobcWBBbiGzIzYRayVBEhQ7rUIsrWXk2f41MWg98r+BDkS2ULExGbfSIRToe1ElOUV4z6imlDp0Pmsv4LmNKSA8ArVwQtlGKN3mQni3zHJWtzw5GrFiT6adt9mSbqbWfyDPpnHdKsnwaDu/rjwTvmnUk+7tMWQ2Lp3pcZCeP5utxCDpc3B3lKs8pdRhAqlhaRGbZ01QqGcIOV1Y9oQGbT4pG11otd29bwWFWJj6UjXw1hYrqR3zIwNOax2nbMZ5M3UkB6zrIw3UyORRjSo9FjkNkgyfttLnHV39TDgF7Aa0GLFBshV+CGoumd7y49LuQk=
   - unset TZ
   - export TZ='Eastern Time (US & Canada)'
 before_install:
@@ -51,7 +50,7 @@ notifications:
     on_success: change
     on_failure: always
   irc:
-    channels: 
-    template: 
+    channels:
+    template:
 dd:
   secure: I3Oa3/YtT0UCRM6gIU7z9ab15bn1DVC9EC9b2zXfCkq02aPbTgkyMYZCBgwEcuIsGcf8Yydl/7r/vZmqyEoMHbqjYB3m6Ct3jHaFpVLor7movIg4mr2lZpRJ0NLzG26b7ICG5AmNlBx+fZGRv/+cjNqVd9AdYCni1Rd3iYjxlBOjgNnCpFNLjVDLcfRZlFzFe7zq4Cz2whF0qgC4NQQNMH0jmLixfOP+JAF+p62aJwKe+qsivpyYLX0FK8W9PMdOGodeBvJY+OOqAk+cAl7BVhoP4QhXVOHvRWvtL1CL/vYITeR+RvckfNUScgGQU3XhkoJ2hzYHafHF5SP3zjecDc7kLnkpe+n9/FLDGp8PDaZStZWpxFzWE4IIMUbgYd3KeXV3bsYktUNWG6R/hnw6Z1JlvLs+anefPnQDBuRU4ygraGtUgXqRSKuaPQODJDA1s5iqVBcXnvRT4oEDDG6NUf8LE1MULUvw+hfCKHVHrhlg9VF/Iee57owwUS0KP1FotvKU2KsV4/yqi54dl7aZQ2MbzrqmRKOSyOG6gxgZ/yXMzAAmy5h3NeIrhhoDz/qmrayN5XaLowvVZsBA7mbmS1GKt+4Qg+Hfoqzc259iP/Iuo6PAxf7SZJ1hl3a4R+zlyacCA4o/wa0UfKG7HN/kNdWWRoCC3kP34Ev5HAdtCjs=


### PR DESCRIPTION
Store the token only on travis.com/reponame/settings/ instead of in each project.  Then we do not have to run the encryption step.  Key is visible only in a Box document.