### PR TITLE
ETDA-1197 Added comments to importer and spec to indicate they are no…

### DIFF
--- a/app/models/legacy/importer.rb
+++ b/app/models/legacy/importer.rb
@@ -1,4 +1,8 @@
+# For importing legacy data during Jan 2019 migration
+# No longer valid
+
 require 'partner'
+
 class Legacy::Importer
   def initialize(records_to_import)
     @display_logger = Logger.new(STDOUT)

--- a/spec/models/legacy/importer_spec.rb
+++ b/spec/models/legacy/importer_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# For importing legacy data during Jan 2019 migration
+# No longer valid
+
 require 'model_spec_helper'
 
 RSpec.describe Legacy::Importer do


### PR DESCRIPTION
… longer to be used.

This ticket was meant to be completed if digsig was done before migration.  Since it wasn't, nothing needs to be done.  I added a comment in the importer and its spec indicating that the importer is old and shouldn't be used.