### PR TITLE
builds out sidekiq configuration from apps redis config

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,16 @@
+
+redis_config = Rails.application.config_for(:redis)
+
+sidekiq_config = Hash.new
+
+sidekiq_config['password'] = redis_config['password'] if redis_config['password']
+sidekiq_url = "redis://#{redis_config.fetch('host', 'localhost')}:#{redis_config.fetch('port', 6379)}"
+sidekiq_config['url'] = sidekiq_url
+
 Sidekiq.configure_server do |config|
-  config.redis = { password: "#{Rails.application.config_for(:redis)['password']}" } unless Rails.env.development?
+  config.redis = sidekiq_config
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { password: "#{Rails.application.config_for(:redis)['password']}" } unless Rails.env.development?
+  config.redis = sidekiq_config
 end


### PR DESCRIPTION
I discovered that the sidekiq configuration wasn't using the RAILS_ENV's redis configuration, this builds out the host, port, and password for the sidekiq configuration 

we'll probably also want to pass in other parameters that are supported, too. I'm still thinking about that

