### PR TITLE
ETDA-1606 Committee member validation to prevent duplicate advisor.  …

### DIFF
--- a/app/models/committee_member.rb
+++ b/app/models/committee_member.rb
@@ -6,7 +6,6 @@ class CommitteeMember < ApplicationRecord
   # This maps ldap values to one or more values needed for committee member autocomplete
   validate :validate_email
   validate :one_head_of_program_check
-  validate :advisor_duplicate_check
   validates :committee_role_id,
             :name,
             :email, presence: true
@@ -117,14 +116,5 @@ class CommitteeMember < ApplicationRecord
 
     errors.add(:committee_role_id, 'An author may only have one Program Head/Chair.')
     false
-  end
-
-  def advisor_duplicate_check
-    return unless submission.present? && committee_role.present? && committee_role.name.include?('Advisor')
-
-    return unless submission.committee_members.select { |member| member.committee_role_id == committee_role_id && ((member.name == name && !name.nil) || member.access_id == access_id || member.email == email) }.count > 1
-
-    errors.add(:committee_role, 'Committee members cannot be listed as an Advisor twice.')
-    true
   end
 end

--- a/spec/models/committee_member_spec.rb
+++ b/spec/models/committee_member_spec.rb
@@ -327,46 +327,4 @@ RSpec.describe CommitteeMember, type: :model do
       expect(cm2).to be_valid
     end
   end
-
-  describe 'advisor_duplicate_check validation' do
-    let(:submission) { FactoryBot.create(:submission) }
-    let(:cm1) { described_class.new }
-    let(:cm2) { described_class.new }
-    let(:committee_role) { FactoryBot.create(:committee_role, name: 'Thesis Advisor/Co-Advisor') }
-
-    before do
-      cm1.name = "Test1"
-      cm2.name = "Test2"
-      cm1.email = "Test1@psu.edu"
-      cm2.email = "Test2@psu.edu"
-      cm1.access_id = "test1"
-      cm2.access_id = "test2"
-      cm1.committee_role = committee_role
-      cm2.committee_role = committee_role
-      submission.committee_members << [cm1, cm2]
-    end
-
-    it 'is valid when advisor does not serve duplicate roles' do
-      expect(cm1).to be_valid
-      expect(cm2).to be_valid
-      cm2.name = cm1.name
-      cm2.committee_role = FactoryBot.create(:committee_role)
-      expect(cm1).to be_valid
-      expect(cm2).to be_valid
-    end
-
-    it 'is invalid when advisor does serve duplicate roles' do
-      cm2.name = cm1.name
-      expect(cm1).to be_invalid
-      expect(cm2).to be_invalid
-      cm2.name = "Test2"
-      cm2.email = cm1.email
-      expect(cm1).to be_invalid
-      expect(cm2).to be_invalid
-      cm2.email = "Test2@psu.edu"
-      cm2.access_id = cm1.access_id
-      expect(cm1).to be_invalid
-      expect(cm2).to be_invalid
-    end
-  end
 end


### PR DESCRIPTION
…Guard clause to prevent infinite redirects if advisor duplicates.  Spec for these.