### PR TITLE
adds smtp_settings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,6 +71,15 @@ Rails.application.configure do
   config.action_mailer.default_options = { from: "no-reply@psu.edu" }
   config.action_mailer.delivery_method = Rails.application.secrets[:email_indicator] || :test
 
+  # SMTP Settings
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch('SMTP_ADDRESS', 'localhost'),
+    port: ENV.fetch('SMTP_PORT', 25),
+    user_name: ENV.fetch('SMTP_USERNAME', nil),
+    password: ENV.fetch('SMTP_PASSWORD', nil),
+    authentication: ENV.fetch('SMTP_AUTHENTICATION_TYPE', nil)
+  }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Allows an administrator to configure the smtp settings for ActionMailer. Tested in kubernetes and on linux. 

to use an smtp host other than what the host is configured for set the `SMTP_ADDRESS` Environment variable (this is currently set in vault, along with the delivery method variable)
