### PR TITLE
Etda 1713

### DIFF
--- a/app/services/submission_release_service.rb
+++ b/app/services/submission_release_service.rb
@@ -117,8 +117,6 @@ class SubmissionReleaseService
       plural_txt = released_total.positive? ? released_total.to_s : 'No'
       result_message = I18n.t('released_message.success', released_count: plural_txt, submissions: 'submission'.pluralize(released_total))
       @error_message = '' unless @error_count.positive?
-      return @error_message if @error_message.present?
-
       [result_message, @error_message]
     end
 

--- a/app/services/submission_release_service.rb
+++ b/app/services/submission_release_service.rb
@@ -24,7 +24,7 @@ class SubmissionReleaseService
     end
     # wait until all submissions and files have been released and then run delta-import to update solr
     bulk_solr_result = SolrDataImportService.new.delta_import
-    return { error: true, msg: "Error occurred during delta-import for solr bulk update" } if bulk_solr_result[:error]
+    return ["Error occurred during delta-import for solr bulk update", ''] if bulk_solr_result[:error]
 
     final_results(submission_ids.count)
   end
@@ -117,6 +117,8 @@ class SubmissionReleaseService
       plural_txt = released_total.positive? ? released_total.to_s : 'No'
       result_message = I18n.t('released_message.success', released_count: plural_txt, submissions: 'submission'.pluralize(released_total))
       @error_message = '' unless @error_count.positive?
+      return @error_message if @error_message.present?
+
       [result_message, @error_message]
     end
 


### PR DESCRIPTION
These changes will handle errors properly for SSET during publication releases.  SSET does not have an explore instance or Solr instance, so it will throw errors when releasing pubs.