### PR TITLE
Etda 1838

### DIFF
--- a/app/controllers/admin/authors_controller.rb
+++ b/app/controllers/admin/authors_controller.rb
@@ -16,7 +16,7 @@ class Admin::AuthorsController < AdminController
     @author.attributes = author_attrs
     @author.save(validate: false)
     # Update each submissions' updated_at timestamp so Solr detects an update
-    @author.submissions.each { |s| s.update :updated_at, DateTime.now }
+    @author.submissions.each { |s| s.update updated_at: DateTime.now }
     outbound_lionpath_record.report_email_change unless @author.submissions.empty?
     redirect_to admin_authors_path
     flash[:notice] = 'Author successfully updated'

--- a/app/controllers/admin/authors_controller.rb
+++ b/app/controllers/admin/authors_controller.rb
@@ -12,7 +12,7 @@ class Admin::AuthorsController < AdminController
     @author = Author.find(params[:id])
     @view = Admin::AuthorView.new(@author)
     outbound_lionpath_record = OutboundLionPathRecord.new(submission: @author.submissions.last, original_alternate_email: @author.alternate_email_address)
-    author_attrs = author_params.merge({ admin_edited_at: DateTime.now })
+    author_attrs = author_params.merge(admin_edited_at: DateTime.now)
     @author.attributes = author_attrs
     @author.save(validate: false)
     # Update each submissions' updated_at timestamp so Solr detects an update

--- a/app/controllers/admin/authors_controller.rb
+++ b/app/controllers/admin/authors_controller.rb
@@ -12,8 +12,11 @@ class Admin::AuthorsController < AdminController
     @author = Author.find(params[:id])
     @view = Admin::AuthorView.new(@author)
     outbound_lionpath_record = OutboundLionPathRecord.new(submission: @author.submissions.last, original_alternate_email: @author.alternate_email_address)
-    @author.attributes = author_params
+    author_attrs = author_params.merge({ admin_edited_at: DateTime.now })
+    @author.attributes = author_attrs
     @author.save(validate: false)
+    # Update each submissions' updated_at timestamp so Solr detects an update
+    @author.submissions.each { |s| s.update :updated_at, DateTime.now }
     outbound_lionpath_record.report_email_change unless @author.submissions.empty?
     redirect_to admin_authors_path
     flash[:notice] = 'Author successfully updated'

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -45,6 +45,4 @@ class Admin < ApplicationRecord
     update(mapped_attributes)
     save(validate: false)
   end
-
-  def refresh_important_attributes; end
 end

--- a/db/migrate/20210204182913_add_admin_edited_at_to_authors.rb
+++ b/db/migrate/20210204182913_add_admin_edited_at_to_authors.rb
@@ -1,0 +1,9 @@
+class AddAdminEditedAtToAuthors < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column :authors, :admin_edited_at, :datetime
+  end
+
+  def self.down
+    remove_column :authors, :admin_edited_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_31_173551) do
+ActiveRecord::Schema.define(version: 2021_02_04_182913) do
 
   create_table "admins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "access_id", default: "", null: false
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 2020_01_31_173551) do
     t.integer "legacy_id"
     t.boolean "confidential_hold"
     t.datetime "confidential_hold_set_at"
+    t.datetime "admin_edited_at"
     t.index ["access_id"], name: "index_authors_on_access_id", unique: true
     t.index ["legacy_id"], name: "index_authors_on_legacy_id"
   end

--- a/lib/devise/strategies/webaccess_authenticatable.rb
+++ b/lib/devise/strategies/webaccess_authenticatable.rb
@@ -19,7 +19,7 @@ module Devise
             end
           else
             obj = a
-            obj.refresh_important_attributes unless obj.class.name == 'Approver'
+            obj.refresh_important_attributes if obj.class.name == 'Author' && obj.admin_edited_at.blank?
           end
           success!(obj)
         else

--- a/spec/factories/authors.rb
+++ b/spec/factories/authors.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
     state { "PA" }
     zip { "16801" }
     updated_at { 4.days.ago }
+    admin_edited_at { nil }
     # inbound_lion_path_record { FactoryBot.create(:inbound_lion_path_record }
   end
 

--- a/spec/integration/admin/manage_authors_spec.rb
+++ b/spec/integration/admin/manage_authors_spec.rb
@@ -11,8 +11,12 @@ RSpec.describe "Manage Authors", js: true do
   end
 
   it 'has a list of authors' do
-    submission1 = FactoryBot.create :submission, :waiting_for_final_submission_response, created_at: Time.zone.now
-    submission2 = FactoryBot.create :submission, :released_for_publication, created_at: (Time.zone.now - 2.years)
+    submission1 = FactoryBot.create :submission, :waiting_for_final_submission_response,
+                                                 created_at: Time.zone.now,
+                                                 updated_at: (Time.zone.now - 2.years)
+    submission2 = FactoryBot.create :submission, :released_for_publication,
+                                                 created_at: (Time.zone.now - 2.years),
+                                                 updated_at: (Time.zone.now - 2.years)
     author1.submissions = [submission1, submission2]
     allow_any_instance_of(LdapUniversityDirectory).to receive(:exists?).and_return(true)
     allow_any_instance_of(Author).to receive(:populate_with_ldap_attributes).and_return(true)
@@ -60,6 +64,8 @@ RSpec.describe "Manage Authors", js: true do
     # expect(page).to have_content('Author successfully updated')
     author1.reload
     expect(author1.admin_edited_at).to be_truthy
+    expect(submission1.updated_at.year).to eq DateTime.now.year
+    expect(submission2.updated_at.year).to eq DateTime.now.year
     visit edit_admin_author_path(author1)
     expect(page).to have_field('First name', with: 'correctname')
     click_link('Cancel')

--- a/spec/integration/admin/manage_authors_spec.rb
+++ b/spec/integration/admin/manage_authors_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe "Manage Authors", js: true do
 
   it 'has a list of authors' do
     submission1 = FactoryBot.create :submission, :waiting_for_final_submission_response,
-                                                 created_at: Time.zone.now,
-                                                 updated_at: (Time.zone.now - 2.years)
+                                    created_at: Time.zone.now,
+                                    updated_at: (Time.zone.now - 2.years)
     submission2 = FactoryBot.create :submission, :released_for_publication,
-                                                 created_at: (Time.zone.now - 2.years),
-                                                 updated_at: (Time.zone.now - 2.years)
+                                    created_at: (Time.zone.now - 2.years),
+                                    updated_at: (Time.zone.now - 2.years)
     author1.submissions = [submission1, submission2]
     allow_any_instance_of(LdapUniversityDirectory).to receive(:exists?).and_return(true)
     allow_any_instance_of(Author).to receive(:populate_with_ldap_attributes).and_return(true)

--- a/spec/integration/admin/manage_authors_spec.rb
+++ b/spec/integration/admin/manage_authors_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe "Manage Authors", js: true do
     click_button('Update Author')
     # expect(page).to have_content('Author successfully updated')
     author1.reload
+    expect(author1.admin_edited_at).to be_truthy
     visit edit_admin_author_path(author1)
     expect(page).to have_field('First name', with: 'correctname')
     click_link('Cancel')

--- a/spec/lib/devise/webaccess_authenticatable_spec.rb
+++ b/spec/lib/devise/webaccess_authenticatable_spec.rb
@@ -61,12 +61,24 @@ RSpec.describe Devise::Strategies::WebaccessAuthenticatable do
 
       context 'with an existing user' do
         before { allow(Author).to receive(:find_by_access_id).with(author.access_id).and_return(author) }
-        it 'authenticates without creating new user and populating attributes' do
-          expect(Author).to receive(:create).with(access_id: author.access_id).never
-          expect_any_instance_of(Author).to receive(:populate_attributes).never
-          expect_any_instance_of(Author).to receive(:refresh_important_attributes).once
-          expect(subject).to be_valid
-          expect(subject.authenticate!).to eq(:success)
+        context 'when author metadata has not been edited by an admin' do
+          it 'authenticates without creating new user and populating attributes' do
+            expect(Author).to receive(:create).with(access_id: author.access_id).never
+            expect_any_instance_of(Author).to receive(:populate_attributes).never
+            expect_any_instance_of(Author).to receive(:refresh_important_attributes).once
+            expect(subject).to be_valid
+            expect(subject.authenticate!).to eq(:success)
+          end
+        end
+        context 'when author metadata has been edited by an admin' do
+          before { author.update admin_edited_at: DateTime.now }
+          it 'authenticates without creating new user, populating attributes, or refreshing attributes' do
+            expect(Author).to receive(:create).with(access_id: author.access_id).never
+            expect_any_instance_of(Author).to receive(:populate_attributes).never
+            expect_any_instance_of(Author).to receive(:refresh_important_attributes).never
+            expect(subject).to be_valid
+            expect(subject.authenticate!).to eq(:success)
+          end
         end
       end
     end
@@ -90,7 +102,6 @@ RSpec.describe Devise::Strategies::WebaccessAuthenticatable do
         it 'authenticates without creating new user and populating attributes' do
           expect(Admin).to receive(:create).with(access_id: admin.access_id).never
           expect_any_instance_of(Admin).to receive(:populate_attributes).never
-          expect_any_instance_of(Admin).to receive(:refresh_important_attributes).once
           expect(subject).to be_valid
           expect(subject.authenticate!).to eq(:success)
         end

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Author, type: :model do
   it { is_expected.to have_db_column(:psu_idn).of_type(:string) }
   it { is_expected.to have_db_column(:confidential_hold).of_type(:boolean) }
   it { is_expected.to have_db_column(:confidential_hold_set_at).of_type(:datetime) }
+  it { is_expected.to have_db_column(:admin_edited_at).of_type(:datetime) }
   it { is_expected.to validate_presence_of(:access_id) }
   it { is_expected.to validate_presence_of(:first_name) }
   it { is_expected.to validate_presence_of(:last_name) }


### PR DESCRIPTION
Tracking if admin has edited an author.  If so we do not refresh attrs from LDAP on login.  Also updating submissions for author when an admin edits the author's metadata.  This is so Solr can detect and update.