### PR TITLE
ETDA-1851

### DIFF
--- a/app/models/lionpath/lionpath_committee_roles.rb
+++ b/app/models/lionpath/lionpath_committee_roles.rb
@@ -16,7 +16,8 @@ class Lionpath::LionpathCommitteeRoles
       degree_type_id: dissertation_id,
       name: row['Description'],
       is_active: status,
-      num_required: 0
+      num_required: 0,
+      lionpath_updated_at: DateTime.now
     }
   end
 

--- a/db/migrate/20210308172751_add_timestamps_to_committee_roles.rb
+++ b/db/migrate/20210308172751_add_timestamps_to_committee_roles.rb
@@ -1,0 +1,11 @@
+class AddTimestampsToCommitteeRoles < ActiveRecord::Migration[6.0]
+  def self.up
+    add_timestamps :committee_roles
+    add_column :committee_roles, :lionpath_updated_at, :datetime
+  end
+
+  def self.down
+    remove_timestamps :committee_roles
+    remove_column :committee_roles, :lionpath_updated_at
+  end
+end

--- a/db/migrate/20210308173409_add_timestamps_to_program_chairs.rb
+++ b/db/migrate/20210308173409_add_timestamps_to_program_chairs.rb
@@ -1,0 +1,9 @@
+class AddTimestampsToProgramChairs < ActiveRecord::Migration[6.0]
+  def self.up
+    add_timestamps :program_chairs
+  end
+
+  def self.down
+    remove_timestamps :program_chairs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_04_182913) do
+ActiveRecord::Schema.define(version: 2021_03_08_173409) do
 
   create_table "admins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "access_id", default: "", null: false
@@ -134,6 +134,9 @@ ActiveRecord::Schema.define(version: 2021_02_04_182913) do
     t.integer "num_required", default: 0, null: false
     t.boolean "is_active", default: true, null: false
     t.string "code"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "lionpath_updated_at"
     t.index ["degree_type_id"], name: "committee_roles_degree_type_id_fk"
   end
 
@@ -216,6 +219,8 @@ ActiveRecord::Schema.define(version: 2021_02_04_182913) do
     t.bigint "phone"
     t.string "email"
     t.datetime "lionpath_updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["program_id"], name: "index_program_chairs_on_program_id"
   end
 

--- a/spec/models/committee_role_spec.rb
+++ b/spec/models/committee_role_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe CommitteeRole, type: :model do
   it { is_expected.to have_db_index(:degree_type_id) }
   it { is_expected.to belong_to(:degree_type).class_name('DegreeType') }
   it { is_expected.to have_many :committee_members }
+  it { is_expected.to have_db_column(:lionpath_updated_at).of_type(:datetime) }
+  it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
+  it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
 
   describe "the CommitteeRole seed data" do
     context "seed committee role data for the current partner" do

--- a/spec/models/lionpath/lionpath_committee_roles_spec.rb
+++ b/spec/models/lionpath/lionpath_committee_roles_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Lionpath::LionpathCommitteeRoles do
     end
 
     it 'updates the existing role' do
-      expect { lionpath_committee_roles.import(row1) }.to change { committee_role.reload.lionpath_updated_at }
+      expect { lionpath_committee_roles.import(row1) }.to(change { committee_role.reload.lionpath_updated_at })
       expect(CommitteeRole.count).to eq 12
       committee_role.reload
       expect(committee_role.is_active).to eq false
@@ -33,7 +33,7 @@ RSpec.describe Lionpath::LionpathCommitteeRoles do
     end
 
     it 'creates a new role' do
-      expect { lionpath_committee_roles.import(row2) }.to change { CommitteeRole.count }.by 1
+      expect { lionpath_committee_roles.import(row2) }.to change(CommitteeRole, :count).by 1
       expect(CommitteeRole.last.name).to eq 'Primary Supervisor'
       expect(CommitteeRole.last.code).to eq 'PRIM'
       expect(CommitteeRole.last.lionpath_updated_at).to be_truthy

--- a/spec/models/lionpath/lionpath_committee_roles_spec.rb
+++ b/spec/models/lionpath/lionpath_committee_roles_spec.rb
@@ -1,0 +1,42 @@
+require 'model_spec_helper'
+
+RSpec.describe Lionpath::LionpathCommitteeRoles do
+  subject(:lionpath_committee_roles) { described_class.new }
+
+  let!(:committee_role) do
+    FactoryBot.create :committee_role, degree_type: DegreeType.default,
+                                       name: 'Outside Unit Member',
+                                       code: 'U',
+                                       lionpath_updated_at: (DateTime.now - 1.minute)
+  end
+
+  context 'when row code matches committee role and status is inactive' do
+    let(:row1) do
+      {
+        'Type' => 'U', 'Status' => 'I', 'Description' => 'Outside Unit Member'
+      }
+    end
+
+    it 'updates the existing role' do
+      expect { lionpath_committee_roles.import(row1) }.to change { committee_role.reload.lionpath_updated_at }
+      expect(CommitteeRole.count).to eq 12
+      committee_role.reload
+      expect(committee_role.is_active).to eq false
+    end
+  end
+
+  context "when no existing committee role matches the row's code" do
+    let(:row2) do
+      {
+        'Type' => 'PRIM', 'Status' => 'A', 'Description' => 'Primary Supervisor'
+      }
+    end
+
+    it 'creates a new role' do
+      expect { lionpath_committee_roles.import(row2) }.to change { CommitteeRole.count }.by 1
+      expect(CommitteeRole.last.name).to eq 'Primary Supervisor'
+      expect(CommitteeRole.last.code).to eq 'PRIM'
+      expect(CommitteeRole.last.lionpath_updated_at).to be_truthy
+    end
+  end
+end

--- a/spec/models/program_chair_spec.rb
+++ b/spec/models/program_chair_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe ProgramChair, type: :model do
   it { is_expected.to have_db_column(:phone).of_type(:integer) }
   it { is_expected.to have_db_column(:email).of_type(:string) }
   it { is_expected.to have_db_column(:lionpath_updated_at).of_type(:datetime) }
+  it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
+  it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
 
   it { is_expected.to belong_to :program }
 end


### PR DESCRIPTION
- Added timestamps to CommitteeRole and ProgramsChair
- Model tests for these
- Updating lionpath_updated_at for CommitteeRole on import
- LP CommitteeRole import tests