### PR TITLE
Etda 1951

### DIFF
--- a/app/models/committee_member.rb
+++ b/app/models/committee_member.rb
@@ -89,6 +89,11 @@ class CommitteeMember < ApplicationRecord
     self[:email] = new_email.strip
     new_access_id = LdapUniversityDirectory.new.retrieve_committee_access_id(self[:email])
     self.access_id = new_access_id
+    return unless committee_member_token.blank? && new_access_id.blank?
+
+    token = CommitteeMemberToken.new authentication_token: SecureRandom.urlsafe_base64(nil, false)
+    self.committee_member_token = token
+    committee_member_token.save!
   end
 
   def committee_role_id=(new_committee_role_id)
@@ -100,12 +105,6 @@ class CommitteeMember < ApplicationRecord
                                    CommitteeRole.find(new_committee_role_id).is_program_head
     self[:is_voting] = false if CommitteeRole.find(new_committee_role_id).name == 'Special Signatory' ||
                                 CommitteeRole.find(new_committee_role_id).is_program_head
-    ldap_result = LdapUniversityDirectory.new.retrieve_committee_access_id(email)
-    return unless committee_member_token.blank? && ldap_result.blank?
-
-    token = CommitteeMemberToken.new authentication_token: SecureRandom.urlsafe_base64(nil, false)
-    self.committee_member_token = token
-    committee_member_token.save!
   end
 
   def name=(new_name)

--- a/app/models/committee_member.rb
+++ b/app/models/committee_member.rb
@@ -89,7 +89,7 @@ class CommitteeMember < ApplicationRecord
     self[:email] = new_email.strip
     new_access_id = LdapUniversityDirectory.new.retrieve_committee_access_id(self[:email])
     self.access_id = new_access_id
-    return unless committee_member_token.blank? && self.access_id.blank?
+    return unless committee_member_token.blank? && access_id.blank?
 
     token = CommitteeMemberToken.new authentication_token: SecureRandom.urlsafe_base64(nil, false)
     self.committee_member_token = token

--- a/app/models/committee_member.rb
+++ b/app/models/committee_member.rb
@@ -89,7 +89,7 @@ class CommitteeMember < ApplicationRecord
     self[:email] = new_email.strip
     new_access_id = LdapUniversityDirectory.new.retrieve_committee_access_id(self[:email])
     self.access_id = new_access_id
-    return unless committee_member_token.blank? && new_access_id.blank?
+    return unless committee_member_token.blank? && self.access_id.blank?
 
     token = CommitteeMemberToken.new authentication_token: SecureRandom.urlsafe_base64(nil, false)
     self.committee_member_token = token

--- a/app/models/lionpath/lionpath_committee.rb
+++ b/app/models/lionpath/lionpath_committee.rb
@@ -22,7 +22,10 @@ class Lionpath::LionpathCommittee
       return if cm_external.present?
     end
 
-    CommitteeMember.create({ submission: this_submission }.merge(committee_member_attrs(row, committee_role)))
+    CommitteeMember.create(
+      { submission: this_submission,
+        email: "#{row['Access ID'].downcase}@psu.edu" }.merge(committee_member_attrs(row, committee_role))
+    )
   end
 
   def self.external_ids
@@ -37,7 +40,6 @@ class Lionpath::LionpathCommittee
       committee_role: committee_role,
       is_required: true,
       name: "#{row['First Name']} #{row['Last Name']}",
-      email: "#{row['Access ID'].downcase}@psu.edu",
       access_id: row['Access ID'].downcase.to_s,
       is_voting: true,
       lionpath_updated_at: DateTime.now

--- a/app/views/admin/submissions/_committee_member_fields.html.erb
+++ b/app/views/admin/submissions/_committee_member_fields.html.erb
@@ -10,7 +10,7 @@
   </div>
   <div class="row committee-details">
     <%= f.input :name, disabled: disabled_bool, input_html: { class: 'ldap-lookup' } %>
-    <%= f.input :email, disabled: disabled_bool %>
+    <%= f.input :email %>
     <div class="status-row">
       <%= f.input :status, collection: Hash[CommitteeMember::STATUS.collect{ |item| [item, item.capitalize] }],
                   label_method: :last, value_method: :first,

--- a/spec/factories/committee_members.rb
+++ b/spec/factories/committee_members.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     submission
     committee_role
     name { "Professor Buck Murphy" }
-    sequence(:email) { |n| "abc#{n}@hotmail.com" }
+    sequence(:email) { |n| "abc#{n}@psu.edu" }
     sequence(:access_id) { |n| "abc#{n}" }
     is_required { true }
     is_voting { true }

--- a/spec/integration/admin/submissions/edit_committee_spec.rb
+++ b/spec/integration/admin/submissions/edit_committee_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Editing committee member information", js: true, honors: true, m
     end
 
     context 'when no committee member is external to PSU' do
-      it 'disables the name, email and committee role fields for this committee member' do
+      it 'disables the name and committee role fields for this committee member (does not disable email)' do
         skip 'graduate only' unless current_partner.graduate?
 
         visit admin_edit_submission_path(submission)
@@ -62,7 +62,7 @@ RSpec.describe "Editing committee member information", js: true, honors: true, m
           expect(find_all("select.role").last.disabled?).to eq true
           expect(find_all("input.ui-autocomplete-input").last.value).to eq 'LP Tester'
           expect(find_all("input.ui-autocomplete-input").last.disabled?).to eq true
-          expect(find_all("input.email").last.disabled?).to eq true
+          expect(find_all("input.email").last.disabled?).to eq false
         end
       end
     end

--- a/spec/integration/special_committee_spec.rb
+++ b/spec/integration/special_committee_spec.rb
@@ -3,7 +3,12 @@ RSpec.describe 'Special committee page', type: :integration, js: true do
 
   let!(:submission) { FactoryBot.create :submission, :waiting_for_committee_review, final_submission_files_uploaded_at: DateTime.now, final_submission_approved_at: DateTime.now }
   let!(:committee_member) { FactoryBot.create :committee_member, submission: submission, status: '', email: 'approverflow@gmail.com' }
-  let!(:committee_member_token) { FactoryBot.create :committee_member_token, committee_member: committee_member, authentication_token: '1' }
+  let!(:committee_member_token) { FactoryBot.create :committee_member_token, authentication_token: '1' }
+
+  before do
+    committee_member.committee_member_token = nil
+    committee_member.committee_member_token = committee_member_token
+  end
 
   it 'displays content' do
     visit '/special_committee/1'
@@ -47,7 +52,9 @@ RSpec.describe 'Special committee page', type: :integration, js: true do
 
   it 'marries an approver and multiple committee member records via token when clicking advance button' do
     committee_member_two = FactoryBot.create :committee_member, submission: submission, status: '', email: 'approverflow@gmail.com'
-    committee_member_token_two = FactoryBot.create :committee_member_token, committee_member: committee_member_two, authentication_token: '2'
+    committee_member_token_two = FactoryBot.create :committee_member_token, authentication_token: '2'
+    committee_member_two.committee_member_token = nil
+    committee_member_two.committee_member_token = committee_member_token_two
     visit '/special_committee/1'
     allow_any_instance_of(Devise::Strategies::OidcAuthenticatable).to receive(:remote_user).and_return('approverflow')
     allow_any_instance_of(LdapUniversityDirectory).to receive(:exists?).and_return(true)

--- a/spec/mailers/workflow_mailer_spec.rb
+++ b/spec/mailers/workflow_mailer_spec.rb
@@ -3,7 +3,7 @@ require 'model_spec_helper'
 RSpec.describe WorkflowMailer do
   let(:submission) { FactoryBot.create :submission }
   let(:committee_member) { FactoryBot.create :committee_member, submission: submission }
-  let(:commmittee_member_token) { FactoryBot.create :committee_member_token, committee_member: committee_member }
+  # let(:commmittee_member_token) { FactoryBot.create :committee_member_token, committee_member: committee_member }
   let(:access_updated_email) do
     {
       author_alternate_email_address: "author alt address",

--- a/spec/mailers/workflow_mailer_spec.rb
+++ b/spec/mailers/workflow_mailer_spec.rb
@@ -3,7 +3,6 @@ require 'model_spec_helper'
 RSpec.describe WorkflowMailer do
   let(:submission) { FactoryBot.create :submission }
   let(:committee_member) { FactoryBot.create :committee_member, submission: submission }
-  # let(:commmittee_member_token) { FactoryBot.create :committee_member_token, committee_member: committee_member }
   let(:access_updated_email) do
     {
       author_alternate_email_address: "author alt address",

--- a/spec/models/committee_member_spec.rb
+++ b/spec/models/committee_member_spec.rb
@@ -148,13 +148,24 @@ RSpec.describe CommitteeMember, type: :model do
         cm.update email: 'test123@psu.edu'
         expect(cm.access_id).to eq 'test123'
       end
+
+      it 'does not add a committee_member_token' do
+        cm.update email: 'test123@psu.edu'
+        expect(cm.committee_member_token).not_to be_present
+      end
     end
 
-    context 'when nil is returned' do
+    context 'when nil is returned from ldap lookup' do
       it "doesn't update access_id" do
         cm.access_id = 'test123'
         allow_any_instance_of(LdapUniversityDirectory).to receive(:retrieve_committee_access_id).and_return(nil)
         expect { cm.update email: 'test123@psu.edu' }.to change(cm, :access_id).to nil
+      end
+
+      it 'adds a committee_member_token' do
+        allow_any_instance_of(LdapUniversityDirectory).to receive(:retrieve_committee_access_id).and_return(nil)
+        cm.update email: 'test123@email.com'
+        expect(cm.committee_member_token).to be_present
       end
     end
 

--- a/spec/models/lionpath/lionpath_committee_spec.rb
+++ b/spec/models/lionpath/lionpath_committee_spec.rb
@@ -58,11 +58,11 @@ RSpec.describe Lionpath::LionpathCommittee do
 
     context 'when submission already has the committee member from the lionpath record' do
       let!(:committee_member) do
-        FactoryBot.create :committee_member, committee_role: committee_role,
-                                             name: 'wrong', access_id: 'abc123', submission: submission
+        FactoryBot.create :committee_member, committee_role: committee_role, name: 'wrong',
+                                             access_id: 'abc123', submission: submission, email: 'abc123@psu.edu'
       end
 
-      it 'updates that committee member record' do
+      it 'updates that committee member record (does not update email)' do
         expect { lionpath_committee.import(row) }.to change { submission.committee_members.count }.by 0
         expect(CommitteeMember.find(committee_member.id).name).to eq 'Test Tester'
         expect(CommitteeMember.find(committee_member.id).committee_role).to eq committee_role

--- a/spec/models/lionpath/lionpath_committee_spec.rb
+++ b/spec/models/lionpath/lionpath_committee_spec.rb
@@ -59,14 +59,14 @@ RSpec.describe Lionpath::LionpathCommittee do
     context 'when submission already has the committee member from the lionpath record' do
       let!(:committee_member) do
         FactoryBot.create :committee_member, committee_role: committee_role, name: 'wrong',
-                                             access_id: 'abc123', submission: submission, email: 'abc123@psu.edu'
+                                             access_id: 'abc123', submission: submission, email: 'xyz321@psu.edu'
       end
 
       it 'updates that committee member record (does not update email)' do
         expect { lionpath_committee.import(row) }.to change { submission.committee_members.count }.by 0
         expect(CommitteeMember.find(committee_member.id).name).to eq 'Test Tester'
         expect(CommitteeMember.find(committee_member.id).committee_role).to eq committee_role
-        expect(CommitteeMember.find(committee_member.id).email).to eq 'abc123@psu.edu'
+        expect(CommitteeMember.find(committee_member.id).email).to eq 'xyz321@psu.edu'
       end
     end
 


### PR DESCRIPTION
Committee member emails are no longer updated during LionPATH import (only created on initial import).  Committee member tokens are created when email changes.  Admins can change committee member emails.