### PR TITLE
SemesterReleaseReportEmail submission query excludes 'Ok to Release' …

### DIFF
--- a/app/mailers/workflow_mailer.rb
+++ b/app/mailers/workflow_mailer.rb
@@ -94,6 +94,7 @@ class WorkflowMailer < ActionMailer::Base
     @date_range = date_range
     attachments[filename.to_s] = csv
     mail to: I18n.t('external_contacts.ul_cataloging.email_address').to_s,
+         cc: I18n.t('devs.lead.primary_email_address'),
          from: current_partner.email_address,
          subject: "eTDs Released Between #{@date_range}"
   end

--- a/app/models/semester_release_report_email.rb
+++ b/app/models/semester_release_report_email.rb
@@ -15,7 +15,7 @@ class SemesterReleaseReportEmail
     end
 
     def filename
-      "ETD_#{Semester.last.split(' ').last.upcase}_RELEASE_REPORT.csv"
+      "ETD_#{Semester.last.gsub(' ', '').upcase}_RELEASE_REPORT.csv"
     end
 
     def headers
@@ -37,7 +37,7 @@ class SemesterReleaseReportEmail
     end
 
     def submissions
-      Submission.where("submissions.status LIKE '%released for publication%'")
+      Submission.where("submissions.status = 'released for publication' AND submissions.access_level = 'open_access'")
                 .where('submissions.released_for_publication_at >= ? AND submissions.released_for_publication_at <= ?',
                        Date.strptime("#{start_month}/01/#{semester_year}", '%m/%d/%Y'), today)
                 .or(Submission.where("submissions.status LIKE '%released for publication%'")
@@ -53,9 +53,9 @@ class SemesterReleaseReportEmail
       if Semester.last.include? 'Spring'
         '02'
       elsif Semester.last.include? 'Summer'
-        '07'
+        '06'
       elsif Semester.last.include? 'Fall'
-        '10'
+        '09'
       else
         '02'
       end

--- a/spec/models/semester_release_report_email_spec.rb
+++ b/spec/models/semester_release_report_email_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe SemesterReleaseReportEmail do
       FactoryBot.create :submission, :final_is_restricted,
                         released_metadata_at: DateTime.strptime("04/10/#{this_year}", "%m/%d/%Y")
     end
+    let!(:submission3) do
+      FactoryBot.create :submission, :final_is_restricted_to_institution,
+                        released_metadata_at: DateTime.strptime("04/10/#{this_year - 2}", "%m/%d/%Y"),
+                        released_for_publication_at: DateTime.strptime("04/10/#{this_year}", "%m/%d/%Y")
+    end
     let(:csv) do
       "Last Name,First Name,Title,Degree Type,Graduation Semester,Released On,Access Level\n#{submission.author.last_name},#{submission.author.first_name},#{submission.title},#{submission.degree.degree_type.name},#{submission.semester} #{submission.year},#{submission.released_for_publication_at.strftime('%D')},#{submission.access_level}\n#{submission2.author.last_name},#{submission2.author.first_name},#{submission2.title},#{submission2.degree.degree_type.name},#{submission2.semester} #{submission2.year},#{submission2.released_metadata_at.strftime('%D')},#{submission2.access_level}\n"
     end
@@ -30,7 +35,7 @@ RSpec.describe SemesterReleaseReportEmail do
       allow(Semester).to receive(:today).and_return Date.strptime("06/30/#{this_year}", "%m/%d/%Y")
     end
 
-    it 'generates a csv from queried submissions' do
+    it 'generates a csv from queried submissions (submission3 should be excluded)' do
       expect(semester_release_report_email.send(:csv)).to eq csv
     end
   end
@@ -74,7 +79,7 @@ RSpec.describe SemesterReleaseReportEmail do
 
     describe '#filename' do
       it 'returns ETD_SPRING_RELEASE_REPORT.csv' do
-        expect(semester_release_report_email.send(:filename)).to eq 'ETD_SPRING_RELEASE_REPORT.csv'
+        expect(semester_release_report_email.send(:filename)).to eq "ETD_#{this_year}SPRING_RELEASE_REPORT.csv"
       end
     end
   end
@@ -100,8 +105,8 @@ RSpec.describe SemesterReleaseReportEmail do
     end
 
     before do
-      allow(Date).to receive(:today).and_return Date.strptime("09/30/#{this_year}", "%m/%d/%Y")
-      allow(Semester).to receive(:today).and_return Date.strptime("09/30/#{this_year}", "%m/%d/%Y")
+      allow(Date).to receive(:today).and_return Date.strptime("08/30/#{this_year}", "%m/%d/%Y")
+      allow(Semester).to receive(:today).and_return Date.strptime("08/30/#{this_year}", "%m/%d/%Y")
     end
 
     describe '#submissions' do
@@ -111,14 +116,14 @@ RSpec.describe SemesterReleaseReportEmail do
     end
 
     describe '#date_range' do
-      it 'returns July 1st - September 31st in standard US format' do
-        expect(semester_release_report_email.send(:date_range)).to eq "07/01/#{this_year} - 09/30/#{this_year}"
+      it 'returns June 1st - August 30th in standard US format' do
+        expect(semester_release_report_email.send(:date_range)).to eq "06/01/#{this_year} - 08/30/#{this_year}"
       end
     end
 
     describe '#filename' do
       it 'returns ETD_SUMMER_RELEASE_REPORT.csv' do
-        expect(semester_release_report_email.send(:filename)).to eq 'ETD_SUMMER_RELEASE_REPORT.csv'
+        expect(semester_release_report_email.send(:filename)).to eq "ETD_#{this_year}SUMMER_RELEASE_REPORT.csv"
       end
     end
   end
@@ -156,14 +161,14 @@ RSpec.describe SemesterReleaseReportEmail do
     end
 
     describe '#date_range' do
-      it 'returns October 1st - January 31st in standard US format' do
-        expect(semester_release_report_email.send(:date_range)).to eq "10/01/#{this_year - 1} - 01/31/#{this_year}"
+      it 'returns September 1st - January 31st in standard US format' do
+        expect(semester_release_report_email.send(:date_range)).to eq "09/01/#{this_year - 1} - 01/31/#{this_year}"
       end
     end
 
     describe '#filename' do
       it 'returns ETD_FALL_RELEASE_REPORT.csv' do
-        expect(semester_release_report_email.send(:filename)).to eq 'ETD_FALL_RELEASE_REPORT.csv'
+        expect(semester_release_report_email.send(:filename)).to eq "ETD_#{this_year - 1}FALL_RELEASE_REPORT.csv"
       end
     end
   end


### PR DESCRIPTION
…submissions.  This report should only capture any submissions that have an initial release or have changed access levels.