### PR TITLE
Hotfix setters

### DIFF
--- a/app/models/committee_member.rb
+++ b/app/models/committee_member.rb
@@ -68,6 +68,8 @@ class CommitteeMember < ApplicationRecord
   end
 
   def status=(new_status)
+    return if self[:status] == new_status
+    
     self[:status] = new_status
     case new_status
     when 'pending'


### PR DESCRIPTION
Allow certain setters in for CommitteeMembers to run their logic even if the new value is the same as the old.