### PR TITLE
937 - removes personal name from email

### DIFF
--- a/config/locales/partners/en/graduate/graduate.en.yml
+++ b/config/locales/partners/en/graduate/graduate.en.yml
@@ -194,7 +194,6 @@ en:
 
                     cc: %{committee_email_list}
 
-                    Fawn Hosterman | Director of Graduate Records
                     J. Jeffrey and Ann Marie Fox Graduate School 
                     %{home_link}
 


### PR DESCRIPTION
closes #937 

Graduate school has requested that their email messages not contain names of administrators. One email did, so this commit removes it.