### PR TITLE
936 - Always show default final submission note

### DIFF
--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -19,7 +19,7 @@ class Admin::SubmissionsController < AdminController
     if @submission.format_review_notes.blank? && !@submission.status_behavior.beyond_waiting_for_format_review_response?
       @submission.format_review_notes = current_partner.graduate? ? I18n.t('graduate.default_format_review_note') : ''
     end
-    return unless @submission.final_submission_notes.blank? && !@submission.status_behavior.beyond_collecting_final_submission_files?
+    return unless @submission.final_submission_notes.blank? && !@submission.status_behavior.beyond_waiting_for_final_submission_response?
 
     @submission.final_submission_notes = current_partner.graduate? ? I18n.t('graduate.default_final_submission_note') : ''
   end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -59,7 +59,6 @@ FactoryBot.define do
       access_level { 'open_access' }
       has_agreed_to_terms { 1 }
       has_agreed_to_publication_release { 1 }
-      final_submission_notes { "Final submission notes" }
       defended_at { Time.zone.yesterday if current_partner.graduate? }
       year { Time.zone.today.year }
       semester { Semester.current.split.last }

--- a/spec/integration/admin/submissions/edit_submission_spec.rb
+++ b/spec/integration/admin/submissions/edit_submission_spec.rb
@@ -195,6 +195,7 @@ RSpec.describe "Editing format review and final submissions as an admin", type: 
   it 'Allows admin to edit final submission content' do
     visit admin_edit_submission_path(final_submission)
     within('#final-submission-information') do
+      expect(page.find_field("Final Submission Notes to Student").value).to eq(I18n.t('graduate.default_final_submission_note'))
       click_link "Additional File"
       all('input[type="file"]').first.set(file_fixture('final_submission_file_01.pdf'))
     end


### PR DESCRIPTION
closes #936 

There was a check to make sure the default final submission note didn't override a blank note if the submission was past a certain point. Unfortunately that check was set to look if final submission was submitted (which would always be true), so this corrects it so the check is now for whether the submission is beyond waiting for final response.