### PR TITLE
add MA, DED, and PhD to program consolidation list

### DIFF
--- a/app/models/solr_submission.rb
+++ b/app/models/solr_submission.rb
@@ -113,6 +113,6 @@ class SolrSubmission < SimpleDelegator
     end
 
     def program_name_condensed
-      program_name.gsub(/ \(MS\)| \(PHD\)/, '')
+      program_name.gsub(/ \(MS\)| \(MA\)| \(DED\)| \(PhD\)| \(PHD\)/, '')
     end
 end

--- a/spec/models/solr_submission_spec.rb
+++ b/spec/models/solr_submission_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SolrSubmission, type: :model do
     let(:format_review_file) { create :format_review_file }
     let(:committee_member_1) { create :committee_member }
     let(:committee_member_2) { create :committee_member }
-    let(:program) { create :program, name: 'Mechanical Engineering (MS)' }
+    let(:program) { create :program, name: 'Mechanical Engineering (DED)' }
     let(:program_name_condensed) { 'Mechanical Engineering' }
 
     it 'generates solr doc from submission attributes' do


### PR DESCRIPTION
Fixes #769 

This should clear up the lingering PhD repeats, but we can check after running a full reindex