### PR TITLE
Disable force_ssl

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,8 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # HTTPS is enforced at the Kubernetes ingress layer, so it is safe to disable
+  config.force_ssl = false
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
We are going to try to open the API endpoint for internal apps only in the k8s cluster.  So, we need to be able to connect via http.  Ingress handles forcing https for external requests, so it is safe to disable.