### PR TITLE
Add error handling to Bugsnag configuration

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -3,4 +3,10 @@
 Bugsnag.configure do |config|
   config.app_version = ENV.fetch('APP_VERSION', nil)
   config.release_stage = ENV.fetch('APP_ENV', 'development')
+
+  config.add_on_error(proc do |event|
+    action = event.request&.dig(:railsAction)
+
+    event.ignore! if action&.start_with?('ok_computer')
+  end)
 end


### PR DESCRIPTION
This pull request updates the Bugsnag error reporting configuration to reduce noise from health check requests. The main change is the addition of logic to ignore errors triggered by `ok_computer` actions.

Error filtering:

* Updated `config/initializers/bugsnag.rb` to ignore errors for requests where the `railsAction` starts with `ok_computer`, preventing health check endpoints from generating unnecessary error reports.