### PR TITLE
Test/remove docker24 pin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
       REGISTRY_URL: harbor.k8s.libraries.psu.edu/library/etda-workflow
     steps:
       - setup_remote_docker:
-          version: docker24
           docker_layer_caching: true
       - checkout
       - run:
@@ -47,7 +46,6 @@ jobs:
       REGISTRY_URL: harbor.k8s.libraries.psu.edu/library/etda-workflow
     steps:
       - setup_remote_docker:
-          version: docker24
           docker_layer_caching: true
       - checkout
       - run:
@@ -70,7 +68,6 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
-          version: docker24
           docker_layer_caching: true
       - checkout
       - run:
@@ -80,6 +77,10 @@ jobs:
             export TAG=${CIRCLE_SHA1}
             export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
             docker-compose up -d db selenium redis
+      - run:
+          name: Capture container logs on failure
+          command: docker-compose logs db selenium redis
+          when: on_fail
       - run:
           name: "Rubocop"
           command: |
@@ -115,7 +116,6 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
-          version: docker24
           docker_layer_caching: true
       - checkout
       - run:
@@ -125,10 +125,17 @@ jobs:
             export TAG=${CIRCLE_SHA1}
             export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
             docker-compose up -d db selenium redis
-            sleep 10
+            until docker-compose exec -T db mysqladmin ping -h localhost -u root --password=root --silent 2>/dev/null; do
+              echo "Waiting for db..."
+              sleep 2
+            done
             PARTNER=graduate docker-compose run --name=test --service-ports -d test
             docker exec -e RAILS_ENV=test -e INTEGRATION=true test /etda_workflow/bin/ci-rspec
             docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
+      - run:
+          name: Capture container logs on failure
+          command: docker-compose logs db selenium redis
+          when: on_fail
   publish:
     docker:
       - image: harbor.k8s.libraries.psu.edu/library/ci-utils:v3.0.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
             export TAG=${CIRCLE_SHA1}
             export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
             docker-compose up -d db selenium redis
-            until docker-compose exec -T db mysqladmin ping -h localhost -u root --password=root --silent 2>/dev/null; do
+            until docker-compose exec -T db mariadb-admin ping -h localhost -u root --password=root --silent 2>/dev/null; do
               echo "Waiting for db..."
               sleep 2
             done


### PR DESCRIPTION
This pull request makes several improvements to the CircleCI configuration, primarily focused on Docker setup reliability and debugging. The most notable changes are the removal of the explicit Docker version in the `setup_remote_docker` steps, improved database readiness checks, and the addition of automatic container log capture on job failures.

**Docker setup and reliability improvements:**

* Removed the explicit `version: docker24` parameter from all `setup_remote_docker` steps to allow CircleCI to use its default Docker version, potentially improving compatibility and reducing maintenance overhead. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L29) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L50) [[3]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L73) [[4]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L118)

* Replaced the fixed `sleep 10` wait after starting the database container with a loop that waits until the MariaDB service is actually ready, improving reliability for tests that depend on the database.

**Debugging enhancements:**

* Added a step to capture and display logs from the `db`, `selenium`, and `redis` containers automatically when a job fails, making it easier to diagnose issues in the CI pipeline. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R80-R83) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L128-R138)