### PR TITLE
Update release-image workflow to include both PROD and ULPROD clusters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ workflows:
 
       - release-image:
           name: release-image
-          clusters: << pipeline.parameters.CLUSTERS_ULPROD >>
+          clusters: << pipeline.parameters.CLUSTERS_PROD >>,<< pipeline.parameters.CLUSTERS_ULPROD >>
           context:
             - org-global
           from_tag: "<< pipeline.git.revision >>"


### PR DESCRIPTION
This pull request updates the deployment configuration in `.circleci/config.yml` to deploy to both the `PROD` and `ULPROD` clusters, instead of just `ULPROD`.

Deployment configuration update:

* Modified the `release-image` job to deploy to both `CLUSTERS_PROD` and `CLUSTERS_ULPROD` clusters by updating the `clusters` parameter. (.circleci/config.yml)