### PR TITLE
1087 - the OTD is replacing the email address

### DIFF
--- a/app/views/author/technical_tips.html.erb
+++ b/app/views/author/technical_tips.html.erb
@@ -49,8 +49,8 @@
     </ul>
 <h2>Committee Members:</h2>
     <ul>
-        <li>For dissertation candidates, committees are imported directly from LionPATH. If changes are needed, please contact gradthesis@psu.edu. Your committee will update in the eTD system the day after the Fox Graduate School has updated your committee appointment in LionPATH.</li>
-        <li>For master’s thesis candidates, there must be at least one thesis advisor. If there is more than one, they must be added as a co-advisor. Your graduate program head/chair is selected from a dropdown on the committee page. If you have questions on updating the program head/chair, please contact gradthesis@psu.edu.</li>
+        <li>For dissertation candidates, committees are imported directly from LionPATH. If changes are needed, please contact thesis@foxgradschool.psu.edu. Your committee will update in the eTD system the day after the Fox Graduate School has updated your committee appointment in LionPATH.</li>
+        <li>For master’s thesis candidates, there must be at least one thesis advisor. If there is more than one, they must be added as a co-advisor. Your graduate program head/chair is selected from a dropdown on the committee page. If you have questions on updating the program head/chair, please contact thesis@foxgradschool.psu.edu.</li>
         <li>For honors thesis candidates, there must be at least one Thesis Supervisor and one Thesis Honors Advisor.</li>
         <li>For Millennium Scholars, there must be at least one thesis supervisor.</li>
         <li>For The School of Science, Engineering, and Technology, there must be at least one Paper Instructor (Advisor), one Paper Reader, and a Department Head.</li>

--- a/config/locales/partners/en/graduate/graduate.en.yml
+++ b/config/locales/partners/en/graduate/graduate.en.yml
@@ -21,7 +21,7 @@ en:
         point7: 'I acknowledge that I cannot make committee changes after the final is submitted. My committee page matches the committee listed in the ETD.'
         point8_masters: "I acknowledge that my approved thesis will be publicly released through the University Libraries as part of the Penn State Graduate Council's master's degree requirements."
         point8_dissertation: "I acknowledge that my approved dissertation will be publicly released through the University Libraries as part of the Penn State Graduate Council's Ph.D. degree requirements."
-        confidential_hold: "Notice: Public release of a %{degree_type} will still occur even with a Confidentiality Hold. If you have any questions or concerns, please contact the Office of Theses and Dissertations in the Graduate School at gradthesis@psu.edu."
+        confidential_hold: "Notice: Public release of a %{degree_type} will still occur even with a Confidentiality Hold. If you have any questions or concerns, please contact the Office of Theses and Dissertations in the Graduate School at thesis@foxgradschool.psu.edu."
         initial: 'Initial here'
       step_one_description: Provide program information
       step_two_description: Provide Committee
@@ -47,18 +47,18 @@ en:
       payment_portal_url: 'https://secure.gradsch.psu.edu/paymentportal/'
       commencement_url: 'https://gradschool.psu.edu/academics/commencement'
       document_title_label: 'Please enter your Thesis or Dissertation Title'
-      extension_not_allowed: 'You are not able to request an extension at this time, please contact your administrator at gradthesis@psu.edu'
+      extension_not_allowed: 'You are not able to request an extension at this time, please contact your administrator at thesis@foxgradschool.psu.edu'
       deadline_url: 'https://gradschool.psu.edu/academics/academic-dates-and-deadlines'
       url_slug: 'etda'
       lionpath_alert: More than 10% of LionPATH %{resource} were tagged for deletion at %{datetime_now}.  The deletion process was not completed because of this.  This could indicate that there was an issue with the LionPATH import or one of the CSVs used during the import.
-      not_allowed_alert: You are not allowed to visit that page at this time, please contact your administrator at gradthesis@psu.edu
+      not_allowed_alert: You are not allowed to visit that page at this time, please contact your administrator at thesis@foxgradschool.psu.edu
       email:
         url: 'https://etda-explore.libraries.psu.edu'
-        address: gradthesis@psu.edu
+        address: thesis@foxgradschool.psu.edu
         list: 'ul-etda-graduate-admin@pennstateoffice365.onmicrosoft.com'
         signature: 'Fox Graduate School <br />Keller Building<br /> University Park, PA'
         contact_information: |
-          If you have questions or comments, please email the Office of Theses and Dissertations at <a href="mailto:gradthesis@psu.edu">gradthesis@psu.edu</a> or call us at (814) 865-1795.
+          If you have questions or comments, please email the Office of Theses and Dissertations at <a href="mailto:thesis@foxgradschool.psu.edu">thesis@foxgradschool.psu.edu</a> or call us at (814) 865-1795.
 
           Best,
 
@@ -258,7 +258,7 @@ en:
         dissertation:
           incomplete_error: Your committee is not complete.  Please contact your graduate program offices to complete your committee.
           help_text: Please review your current and official committee. Dissertation Committees are imported from LionPATH based on your approved committee appointment signature form.  Any concerns should be directed to your graduate program offices.  Any changes to the committee members presented below will require new official paperwork. Special Member information is not imported from LionPATH. If your committee requires a Special Member, you will see an empty box below for that member's information. Please fill in this data before submitting the form.
-          notice: Special Signatories (not to be confused with special members) can be added at the bottom of the screen by clicking “Add Special Signatory”.  The role will populate to Special Signatory and is the only option available to add here.  Note that if these members are external to Penn State and do not have Access IDs, they will be prompted to create a OneID account when they visit this site.  For questions regarding Special Signatories please contact <a href="mailto:gradthesis@psu.edu">gradthesis@psu.edu</a>.
+          notice: Special Signatories (not to be confused with special members) can be added at the bottom of the screen by clicking “Add Special Signatory”.  The role will populate to Special Signatory and is the only option available to add here.  Note that if these members are external to Penn State and do not have Access IDs, they will be prompted to create a OneID account when they visit this site.  For questions regarding Special Signatories please contact <a href="mailto:thesis@foxgradschool.psu.edu">thesis@foxgradschool.psu.edu</a>.
           members:
             lionpath_committee:
               name: LionPATH Committee
@@ -365,7 +365,7 @@ en:
         notes_for_student_label: "Notes for Student (required only if rejecting)"
         submit_button: "Submit Review"
     approval_help:
-      message: "If you know you need to approve a student's work, but do not see it in your queue or the link is broken, your ability to vote has expired. To resolve this issue, please try clearing your cache and then trying the link again or try the link on a different browser. If that doesn't work, please call OTD at 814-865-5448 or email us at <a href='mailto:gradthesis@psu.edu' target='_blank'>gradthesis@psu.edu</a> so that we may proxy for you."
+      message: "If you know you need to approve a student's work, but do not see it in your queue or the link is broken, your ability to vote has expired. To resolve this issue, please try clearing your cache and then trying the link again or try the link on a different browser. If that doesn't work, please call OTD at 814-865-5448 or email us at <a href='mailto:thesis@foxgradschool.psu.edu' target='_blank'>thesis@foxgradschool.psu.edu</a> so that we may proxy for you."
     default_format_review_note:
       "The documents below contain your format review corrections, information on supporting materials, and the graduation checklist. Please refer to the Thesis and Dissertation Handbook when making corrections. \n \n The next step is to submit your final thesis/dissertation. The final thesis/dissertation must be reviewed and approved by all committee members and all changes made before it is uploaded to the eTD site for electronic approval. Formatting changes requested by the Office of Theses and Dissertations will be the only changes permitted after the final is uploaded."
     default_final_submission_note:

--- a/config/locales/partners/en/honors/honors.en.yml
+++ b/config/locales/partners/en/honors/honors.en.yml
@@ -135,12 +135,9 @@ en:
 
                     Request extension: %{url}
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at thesis@foxgradschool.psu.edu.
-                    You may also call (814)865-5448, or send mail to:
-                    Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
+                    If you have any further questions, please contact:  
+                    Sarah Richards, Coordinator of Student Records & Advising Services
+                    SHCAcademics@psu.edu
         release_for_publication:
           message: |
                     Congratulations! Your honors thesis titled "%{title}" has been released for publication with the access level of Open Access. You can view it at: %{url}.

--- a/config/locales/partners/en/honors/honors.en.yml
+++ b/config/locales/partners/en/honors/honors.en.yml
@@ -135,7 +135,7 @@ en:
 
                     Request extension: %{url}
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
+                    If you have questions or comments, please email the Office of Theses and Dissertations at thesis@foxgradschool.psu.edu.
                     You may also call (814)865-5448, or send mail to:
                     Office of Theses and Dissertations
                     115 Kern Building


### PR DESCRIPTION
The OTD is switching from gradthesis@psu.edu to thesis@foxgradschool.psu.edu.

closes #1087