### PR TITLE
Solr9: Enhance Solr document metadata with author name and publication date 

### DIFF
--- a/app/models/solr_submission.rb
+++ b/app/models/solr_submission.rb
@@ -19,7 +19,7 @@ class SolrSubmission < SimpleDelegator
 
     def field_semantics
       {
-        year: 'year_isi',
+        year: ['year_isi', 'pub_date_si'],
         public_id: 'id',
         final_submission_files_uploaded_at_dtsi: 'final_submission_files_uploaded_at_dtsi',
         final_submission_legacy_old_id: 'db_legacy_old_id',
@@ -28,6 +28,7 @@ class SolrSubmission < SimpleDelegator
         file_name_ssim: 'file_name_ssim',
         remediated_file_name_ssim: 'remediated_file_name_ssim',
         author_name_tesi: 'author_name_tesi',
+        author_name_ssi: 'author_ssi',
         author_last_name: ['last_name_ssi', 'last_name_tesi'],
         author_middle_name: ['middle_name_ssi'],
         author_first_name: 'first_name_ssi',
@@ -40,7 +41,7 @@ class SolrSubmission < SimpleDelegator
         committee_member_emails: ['committee_member_email_ssim'],
         committee_member_and_role: ['committee_member_and_role_tesim', 'committee_member_role_ssim'],
         keyword_list: ['keyword_ssim', 'keyword_tesim'],
-        title: ['title_ssi', 'title_tesi'],
+        title: ['title_ssi', 'title_tesi', 'title_si'],
         id: ['db_id'],
         adjusted_access_level: 'access_level_ss',
         semester: 'semester_ssi',
@@ -101,6 +102,10 @@ class SolrSubmission < SimpleDelegator
 
     def author_name_tesi
       "#{author.last_name}, #{author.first_name} #{author.middle_name}"
+    end
+
+    def author_name_ssi
+      author_name_tesi
     end
 
     def author_email_ssi

--- a/config/database.yml
+++ b/config/database.yml
@@ -53,4 +53,4 @@ production:
 
 development:
   <<: *default
-  database: "etda_workflow"
+  database: <%= ENV.fetch("MYSQL_DATABASE") { "etda_workflow" } %>

--- a/spec/models/solr_submission_spec.rb
+++ b/spec/models/solr_submission_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe SolrSubmission, type: :model do
                                               "abstract_tesi" => submission.abstract,
                                               "access_level_ss" => converted_access_level,
                                               "author_name_tesi" => "#{submission.author_last_name}, #{submission.author_first_name} #{submission.author_middle_name}",
+                                              "author_ssi" => "#{submission.author_last_name}, #{submission.author_first_name} #{submission.author_middle_name}",
                                               "author_email_ssi" => submission.author.psu_email_address,
                                               "committee_member_and_role_tesim" => ["#{committee_member_1.name}, #{committee_member_1.committee_role.name}",
                                                                                     "#{committee_member_2.name}, #{committee_member_2.committee_role.name}"],
@@ -77,8 +78,10 @@ RSpec.describe SolrSubmission, type: :model do
                                               "middle_name_ssi" => submission.author_middle_name,
                                               "program_name_ssi" => program_name_condensed,
                                               "program_name_tesi" => program_name_condensed,
+                                              "pub_date_si" => submission.year,
                                               "released_metadata_at_dtsi" => submission.released_metadata_at.to_datetime.getutc,
                                               "semester_ssi" => submission.semester,
+                                              "title_si" => submission.title,
                                               "title_ssi" => submission.title,
                                               "title_tesi" => submission.title,
                                               "year_isi" => submission.year


### PR DESCRIPTION
Solr9: 
This pull request updates the Solr submission model and its tests to improve metadata mapping and search capabilities. The main changes include expanding the mapping of certain fields to support additional Solr field names, introducing a new author name field, and updating the database configuration for better environment flexibility.

**Solr field mapping enhancements:**

* The `year` field now maps to both `year_isi` and `pub_date_si` to support broader date-based queries.
* The `title` field now includes `title_si` in addition to `title_ssi` and `title_tesi` for improved title searching.
* Added `author_name_ssi` mapping and corresponding method to provide an alternate author name field in Solr. [[1]](diffhunk://#diff-42f6a097d46ced055c2b11caed4b8b477940e2fc25cd6224d0dd1cc1823fc5f6R31) [[2]](diffhunk://#diff-42f6a097d46ced055c2b11caed4b8b477940e2fc25cd6224d0dd1cc1823fc5f6R107-R110)

**Configuration improvements:**

* Updated the development database configuration in `database.yml` to allow the database name to be set via the `MYSQL_DATABASE` environment variable, improving deployment flexibility.

**Test updates:**

* Adjusted the Solr submission spec to verify the new and updated field mappings, including checks for `author_ssi`, `pub_date_si`, and `title_si`. [[1]](diffhunk://#diff-157c52481819c8937cfd5f987e93ea629cc35ee0b41b97758e4b3903d6798c95R46) [[2]](diffhunk://#diff-157c52481819c8937cfd5f987e93ea629cc35ee0b41b97758e4b3903d6798c95R81-R84)