### PR TITLE
reset remediation fields when job fails for potentially transient errors

### DIFF
--- a/app/controllers/webhooks/remediation_results_controller.rb
+++ b/app/controllers/webhooks/remediation_results_controller.rb
@@ -21,6 +21,14 @@ class Webhooks::RemediationResultsController < Webhooks::BaseController
 
   private
 
+    RESET_REMEDIATION_ERRORS = [
+      'Owner must belong to a unit to validate page quota',
+      'must be greater than 0',
+      'exceeds the unit\'s overall page limit',
+      'exceeds the user\'s daily page limit',
+      'must be an integer'
+    ].freeze
+
     def authenticate_request
       secret = ExternalApp.pdf_accessibility_api.token
 
@@ -38,8 +46,20 @@ class Webhooks::RemediationResultsController < Webhooks::BaseController
     end
 
     def handle_failure(job_data)
-      Rails.logger.error("Auto-remediation job failed: #{job_data[:processing_error_message]}")
-      render json: { message: job_data[:processing_error_message] }, status: :ok
+      error_message = job_data[:processing_error_message]
+
+      Rails.logger.error("Auto-remediation job failed: #{error_message}")
+
+      if RESET_REMEDIATION_ERRORS.any? { |message| error_message.include?(message) }
+        final_submission_file = FinalSubmissionFile.find_by(remediation_job_uuid: job_data[:uuid])
+
+        final_submission_file&.update_columns(
+          remediation_started_at: nil,
+          remediation_job_uuid: nil
+        )
+      end
+
+      render json: { message: error_message }, status: :ok
     end
 
     def remediation_results_params

--- a/app/views/admin/user_guide.html.erb
+++ b/app/views/admin/user_guide.html.erb
@@ -9,7 +9,6 @@
   <p class="question">How can I move a submission out of “Final Submission is Pending” (committee review stage)?</p>
   <p class="answer">Scroll to the bottom of the submission and choose “Reject & return to author”.<br>When you perform this action, you do not need to alter anyone's votes.  It ends the process there and kicks it back for the student to resubmit.  This marks the submission as “Committee Review Rejected”.</p>
 
-
   <p class="question">I am changing the committee members' statuses to approved/reject but the submission is not moving forward/backwards.</p>
   <p class="answer">This method only works at the “Final Submission is Pending” stage.  If the submission is in “Committee Review Rejected” or “Final Submission is Incomplete” you must wait for the student to resubmit. If it is in “Final Submission to be Released”, you must use the buttons at the bottom of the submission screen.</p>
 

--- a/app/workers/auto_remediate_worker.rb
+++ b/app/workers/auto_remediate_worker.rb
@@ -11,7 +11,17 @@ class AutoRemediateWorker
     # it needs to know the URL structure of ETDA Explore, without any shared code.
     download_url = "#{EtdUrls.new.explore}/files/final_submissions/#{file.id}"
 
-    remediation_job_uuid = PdfRemediation::Client.new(download_url).request_remediation
+    remediation_job_uuid = begin
+      PdfRemediation::Client.new(download_url).request_remediation
+    rescue PdfRemediation::Client::InvalidFileURL
+      raise
+    rescue StandardError => e
+      # Errors at this stage are likely to be transient (except InvalidFileURL), so we reset the remediation_started_at timestamp so that the file can be retried later.
+      Rails.logger.error("AutoRemediateWorker remediation request failed for FinalSubmissionFile #{final_submission_file_id}: #{e.class}: #{e.message}")
+      file.update_column(:remediation_started_at, nil)
+      raise
+    end
+
     file.update_column(:remediation_job_uuid, remediation_job_uuid)
   end
 end

--- a/spec/requests/webhooks/remediation_results_spec.rb
+++ b/spec/requests/webhooks/remediation_results_spec.rb
@@ -33,18 +33,34 @@ RSpec.describe 'Webhooks::RemediationResults', type: :request do
 
     context 'when remediation has failed' do
       let(:event_type) { 'job.failed' }
-      let(:error_message) { 'Some error message' }
 
-      it 'logs the failure message from the PDF API' do
-        original_logger = Rails.logger
-        log_output = StringIO.new
-        Rails.logger = ActiveSupport::Logger.new(log_output)
+      context 'when the error message indicates a transient error' do
+        let(:error_message) { '50 exceeds the unit\'s overall page limit' }
+        let!(:final_submission_file) { create(:final_submission_file, remediation_job_uuid:) }
 
-        headers = { 'CONTENT_TYPE' => 'application/json', 'X-API-KEY' => pdf_api_app.token }
-        post path, params: params.to_json, headers: headers
-        expect(log_output.string).to include('Some error message')
-      ensure
-        Rails.logger = original_logger
+        it 'resets the remediation_started_at timestamp and remediation_job_uuid' do
+          headers = { 'CONTENT_TYPE' => 'application/json', 'X-API-KEY' => pdf_api_app.token }
+          post path, params: params.to_json, headers: headers
+          final_submission_file.reload
+          expect(final_submission_file.remediation_started_at).to be_nil
+          expect(final_submission_file.remediation_job_uuid).to be_nil
+        end
+      end
+
+      context 'when the error message indicates a non-transient error' do
+        let(:error_message) { 'Some error message' }
+
+        it 'logs the failure message from the PDF API' do
+          original_logger = Rails.logger
+          log_output = StringIO.new
+          Rails.logger = ActiveSupport::Logger.new(log_output)
+
+          headers = { 'CONTENT_TYPE' => 'application/json', 'X-API-KEY' => pdf_api_app.token }
+          post path, params: params.to_json, headers: headers
+          expect(log_output.string).to include('Some error message')
+        ensure
+          Rails.logger = original_logger
+        end
       end
     end
 

--- a/spec/requests/webhooks/remediation_results_spec.rb
+++ b/spec/requests/webhooks/remediation_results_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Webhooks::RemediationResults', type: :request do
                output_url: output_url,
                processing_error_message: error_message } }
     end
-    let(:final_submission_file) { create(:final_submission_file, :remediate) }
+    let!(:final_submission_file) { create(:final_submission_file, :remediate) }
 
     before do
       allow(BuildRemediatedFileWorker).to receive(:perform_async).with(remediation_job_uuid, output_url)

--- a/spec/requests/webhooks/remediation_results_spec.rb
+++ b/spec/requests/webhooks/remediation_results_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Webhooks::RemediationResults', type: :request do
                output_url: output_url,
                processing_error_message: error_message } }
     end
+    let(:final_submission_file) { create(:final_submission_file, :remediate) }
 
     before do
       allow(BuildRemediatedFileWorker).to receive(:perform_async).with(remediation_job_uuid, output_url)
@@ -36,7 +37,6 @@ RSpec.describe 'Webhooks::RemediationResults', type: :request do
 
       context 'when the error message indicates a transient error' do
         let(:error_message) { '50 exceeds the unit\'s overall page limit' }
-        let!(:final_submission_file) { create(:final_submission_file, remediation_job_uuid:) }
 
         it 'resets the remediation_started_at timestamp and remediation_job_uuid' do
           headers = { 'CONTENT_TYPE' => 'application/json', 'X-API-KEY' => pdf_api_app.token }
@@ -58,6 +58,8 @@ RSpec.describe 'Webhooks::RemediationResults', type: :request do
           headers = { 'CONTENT_TYPE' => 'application/json', 'X-API-KEY' => pdf_api_app.token }
           post path, params: params.to_json, headers: headers
           expect(log_output.string).to include('Some error message')
+          expect(final_submission_file.reload.remediation_started_at).not_to be_nil
+          expect(final_submission_file.reload.remediation_job_uuid).not_to be_nil
         ensure
           Rails.logger = original_logger
         end

--- a/spec/workers/auto_remediate_worker_spec.rb
+++ b/spec/workers/auto_remediate_worker_spec.rb
@@ -28,6 +28,23 @@ RSpec.describe AutoRemediateWorker do
       expect { described_class.new.perform(file.id) }.to raise_error(PdfRemediation::Client::MissingConfiguration)
       expect(file.reload.remediation_job_uuid).to be_nil
     end
+
+    context 'when a transient error occurs during remediation request' do
+      let(:transient_error) { StandardError.new('Transient error') }
+
+      before do
+        allow(PdfRemediation::Client).to receive(:new).with(expected_download_url).and_raise(transient_error)
+      end
+
+      it 'resets the remediation_started_at timestamp and does not update the job UUID' do
+        file.update_column(:remediation_started_at, Time.current)
+
+        expect { described_class.new.perform(file.id) }.to raise_error(StandardError, 'Transient error')
+
+        expect(file.reload.remediation_started_at).to be_nil
+        expect(file.reload.remediation_job_uuid).to be_nil
+      end
+    end
   end
 
   describe '.perform_async' do


### PR DESCRIPTION
Fixes #1055 

My concern with a rake task was that things could end up in an endless cycle of being reset/failing. Instead I went with reseting fields at two different points in the remediation process so that remediation is only retried if it is explicitly requested again. First reset check is if the initial call fails and covers connection error, invalid api key, etc. The second is if we get an error back from the remediation tool. For that, I stuck to page limit related errors for now but set it up so we can easily add other errors if we see other reset eligible ones from AWS or Adobe popping up frequently.